### PR TITLE
Remove README.md as packaged data in the wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import setuptools
 
-with open('README.md', 'r') as readme:
-    long_description = readme.read()
+try:
+    with open('README.md', 'r') as readme:
+        long_description = readme.read()
+except Exception:
+    long_description = ''
 
 setuptools.setup(
     name='python-string-utils',
@@ -23,7 +26,6 @@ setuptools.setup(
     ],
     keywords='string str utilities validation compression development',
     packages=['string_utils'],
-    data_files=[('README', ['README.md'])],
     python_requires='>=3.5',
     setup_requires=['wheel'],
 )


### PR DESCRIPTION
README.md is not needed here except for reading to provide the
`long_description` attribute in `setup.py`, which is then used only
when uploading to pypi. It seems we can safely remove it from the
manifest while retaining it in git.

Normally the `data` published here is for non-python files necessary
for the program to function (e.g., i18n translations).